### PR TITLE
pass class names to the <img> tag

### DIFF
--- a/addon/mixins/light-box.js
+++ b/addon/mixins/light-box.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 
 export default Ember.Mixin.create({
     tagName: 'a',
-    attributeBindings: ['href', 'data-lightbox', 'data-title'],
+    attributeBindings: ['href', 'data-lightbox', 'data-title', 'data-class'],
     inlineImage: true,
     classNames: ['ember-lightbox'],
     classNameBindings: ['inlineImage']

--- a/app/templates/components/light-box.hbs
+++ b/app/templates/components/light-box.hbs
@@ -1,1 +1,1 @@
-{{#if inlineImage}}<img {{bind-attr src=href }} {{bind-attr title=data-title }}/>{{/if}}{{yield}}
+{{#if inlineImage}}<img src="{{unbound href}}" title="{{unbound data-title}}" class="{{unbound data-class}}"/>{{/if}}{{yield}}


### PR DESCRIPTION
The commit is about passing class names to the `<img>` tag. An escenario is passing the `img-responsive` class when using Bootstrap.

I changed `bind-attr` for `unbound`. I don't see why we would want to keep around un-used binds, please correct me if I'm missing a use case.
