### PR TITLE
set bower lightbox directory as `lightbox` rather than `lightbox2`

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ module.exports = {
     },
     included: function lightbox_included(app) {
         this._super.included.apply(this, arguments);
-        var lightboxPath = path.join(app.bowerDirectory, 'lightbox2', 'dist'),
+        var lightboxPath = path.join(app.bowerDirectory, 'lightbox', 'dist'),
             lightboxCssContent = fs.readFileSync(path.join(lightboxPath, 'css', 'lightbox.css'),'utf8');
         lightboxCssContent = lightboxCssContent.replace(/\.\.\/images\//g, 'images/lightbox/');
         fs.writeFileSync(path.join(lightboxPath, 'css', 'lightbox.processed.css'), lightboxCssContent);


### PR DESCRIPTION
Just tried to install this addon but failed with not being able to find the bower components when running `ember s`. Looks like lightbox have renamed their bower directory back to straight `lightbox`. from `lightbox2`